### PR TITLE
Void contents requirement if template_id exists

### DIFF
--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -214,6 +214,11 @@ class OneSignalClient
 
         ];
 
+	// Void requirement of 'contents' if 'template_id' is set
+        if(array_key_exists('template_id', $data) && !empty($data['template_id'])) {
+            $valid_params['contents'] = false;
+        }
+
         $clean_data = [];
 
         // Loop on all of the available parameters (we're sanitizing our data)


### PR DESCRIPTION
The forced requirement of the "contents" parameter is preventing the use of templates.
From the docs: 
<img width="801" alt="screen shot 2017-05-09 at 18 28 58" src="https://cloud.githubusercontent.com/assets/4737073/25865157/3af54322-34f2-11e7-9276-60a863ef41f5.png">
